### PR TITLE
Jedis 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
 
 <dependencies>
   <dependency>
-      <groupId>com.xargsgrep</groupId>
+      <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.2.2-SNAPSHOT</version>
+      <version>2.4.2</version>
       <type>jar</type>
       <scope>compile</scope>
   </dependency>
@@ -30,10 +30,6 @@
     <repository>
         <id>repo.codahale.com</id>
         <url>http://repo.codahale.com</url>
-    </repository>
-    <repository>
-        <id>oss.sonatype.org</id>
-        <url>https://oss.sonatype.org/content/groups/public</url>
     </repository>
 </repositories>
 

--- a/pom_2.9.2.xml
+++ b/pom_2.9.2.xml
@@ -14,7 +14,7 @@
   <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.1.0</version>
+      <version>2.4.2</version>
       <type>jar</type>
       <scope>compile</scope>
   </dependency>


### PR DESCRIPTION
Bumped version of Jedis to 2.4.2. And removed snapshot dependency.

Also changed the jedis group back to the original redis.clients which was my original reason for yak shaving as it caused other transitive dependencies issues.

Removed reference to Sonatype repository as I could not see the need for it anymore.

Not able to test with JedisSentinelPool so please test sentinels first before merging?
