### PR TITLE
Handle null values in hmget wrapper

### DIFF
--- a/src/main/scala/sedis.scala
+++ b/src/main/scala/sedis.scala
@@ -20,8 +20,8 @@ trait Dress {
       j.hmset(key,values.asJava)
     }
 
-    def hmget(key: String, values: String*): List[String] = {
-      j.hmget(key,values: _*).asScala.toList
+    def hmget(key: String, values: String*): List[Option[String]] = {
+      j.hmget(key,values: _*).asScala.toList.map(Option.apply)
     }
     
     def hgetAll(key: String): Map[String,String] = {


### PR DESCRIPTION
`hmget` can return `null`s (for the fields not defined in the hash). A more
correct return type is `List[Option[String]]`.

Fixes #16